### PR TITLE
Change magenta to black for sh-quoted-exec

### DIFF
--- a/monotropic-theme.el
+++ b/monotropic-theme.el
@@ -243,6 +243,9 @@
    `(feebleline-bufname-face ((t (:foreground ,fg-light))))
    `(feebleline-previous-buffer-face ((t (:foreground ,fg-light))))
    `(feebleline-asterisk-face ((t (:foreground ,fg-light))))
+   
+   ;; shell-script mode
+   `(sh-quoted-exec ((t (:background ,bg :foreground ,fg))))
 
    ;; misc
     `(hl-line ((t (:background "#fcfaf0" ))))


### PR DESCRIPTION
This fixes magenta coloured commands in $(...) or `` in shell-script mode.